### PR TITLE
Sanitise leetcode url

### DIFF
--- a/src/coding_tasks/templates/coding_tasks/edit_tasks.html
+++ b/src/coding_tasks/templates/coding_tasks/edit_tasks.html
@@ -47,7 +47,7 @@
                         </div>
                         <input type="text" class="form-control col-sm-5" placeholder="Name" v-model="task.name"/>
                         <input type="url" class="form-control col-sm-5" placeholder="URL" v-model="task.url"
-                               @input="guess_name(idx)"/>
+                               @input="process_name(idx)"/>
                         <button type="button" class="close col-sm-1" @click="clean_or_remove_at(idx)">&times;</button>
                     </div>
                 </li>
@@ -114,7 +114,7 @@
                 },
                 add_task(url = '') {
                     this.tasks.push({id: this.next_id, name: '', url: url});
-                    this.guess_name(this.next_id);
+                    this.process_name(this.next_id);
                     this.next_id = this.next_id + 1;
                 },
                 async save_tasks() {
@@ -161,11 +161,21 @@
                     this.deleted_suggestions.push(this.suggestions[idx].id);
                     this.suggestions.splice(idx, 1);
                 },
-                guess_name(idx) {
+                process_name(idx) {
                     const url = this.tasks[idx].url;
-                    if (this.tasks[idx].name === '' && url.startsWith('https://leetcode.com/problems/')) {
-                        const name = TASK_URLS_TO_NAMES[url];
-                        if (name) this.tasks[idx].name = name;
+                    if (url.startsWith('https://leetcode.com/problems/')) {
+                        let sanitized_url = url;
+                        if (sanitized_url.includes('/description/') || url.includes('/submissions/')) {
+                            sanitized_url = url.replace('/description/', '/').replace('/submissions/', '/');
+                        }
+                        if (!sanitized_url.endsWith('/')) {
+                            sanitized_url += '/';
+                        }
+                        this.tasks[idx].url = sanitized_url;
+                        if (this.tasks[idx].name === '') {
+                            const name = TASK_URLS_TO_NAMES[sanitized_url];
+                            if (name) this.tasks[idx].name = name;
+                        }
                     }
                 },
             },

--- a/src/coding_tasks/utils.py
+++ b/src/coding_tasks/utils.py
@@ -10,6 +10,6 @@ def strip_description_path(url):
         str: The url without the suffix.
     """
     if url.startswith("https://leetcode.com/problems/"):
-        return re.sub(r"/(description|submissions)/?$", "", url)
+        return re.sub(r"/(description|submissions)/?$", "/", url)
     else:
         return url

--- a/src/coding_tasks/utils.py
+++ b/src/coding_tasks/utils.py
@@ -1,0 +1,15 @@
+import re
+
+def strip_description_path(url):
+    """Remove the /description or /submissions suffix from a leetcode.com url, if present.
+
+    Args:
+        url (str): The url to sanitise.
+
+    Returns:
+        str: The url without the suffix.
+    """
+    if url.startswith("https://leetcode.com/problems/"):
+        return re.sub(r"/(description|submissions)/?$", "", url)
+    else:
+        return url

--- a/src/coding_tasks/views/users.py
+++ b/src/coding_tasks/views/users.py
@@ -12,7 +12,7 @@ from coding_tasks.forms import (
     UserUpdateForm,
 )
 from coding_tasks.models import Suggestion
-from coding_tasks.utils import strip_description_path # Import the helper function
+from coding_tasks.utils import strip_description_path
 
 
 class UserUpdateView(LoginRequiredMixin, MultiModelFormView):
@@ -36,7 +36,7 @@ class SuggestionAddView(LoginRequiredMixin, RedirectView):
         form = SuggestionAddForm(request.POST)
         if form.is_valid():
             url = form.cleaned_data["url"]
-            url = strip_description_path(url) # Call the helper function to sanitise the url
+            url = strip_description_path(url)
             Suggestion.objects.update_or_create(
                 url=url, defaults={"user": request.user}
             )

--- a/src/coding_tasks/views/users.py
+++ b/src/coding_tasks/views/users.py
@@ -12,6 +12,7 @@ from coding_tasks.forms import (
     UserUpdateForm,
 )
 from coding_tasks.models import Suggestion
+from coding_tasks.utils import strip_description_path # Import the helper function
 
 
 class UserUpdateView(LoginRequiredMixin, MultiModelFormView):
@@ -35,6 +36,7 @@ class SuggestionAddView(LoginRequiredMixin, RedirectView):
         form = SuggestionAddForm(request.POST)
         if form.is_valid():
             url = form.cleaned_data["url"]
+            url = strip_description_path(url) # Call the helper function to sanitise the url
             Suggestion.objects.update_or_create(
                 url=url, defaults={"user": request.user}
             )


### PR DESCRIPTION
This pull request primarily focuses on improving the handling of URLs in the `coding_tasks` application. The changes include renaming a method from `guess_name` to `process_name`, enhancing the URL processing logic in the `process_name` method, and adding a new utility function `strip_description_path` to sanitize URLs.

URL Handling Improvements:

* [`src/coding_tasks/templates/coding_tasks/edit_tasks.html`](diffhunk://#diff-bd392b058b00d3014a3d3ffe85d003ae98c68248f5477716897f378b3718974dL50-R50): The method `guess_name` was renamed to `process_name` and its logic was enhanced to sanitize URLs by removing '/description/' or '/submissions/' if present, and ensuring the URL ends with '/'. This method is now called when a task's URL is updated and when a new task is added. [[1]](diffhunk://#diff-bd392b058b00d3014a3d3ffe85d003ae98c68248f5477716897f378b3718974dL50-R50) [[2]](diffhunk://#diff-bd392b058b00d3014a3d3ffe85d003ae98c68248f5477716897f378b3718974dL117-R117) [[3]](diffhunk://#diff-bd392b058b00d3014a3d3ffe85d003ae98c68248f5477716897f378b3718974dL164-R179)

New Utility Function:

* [`src/coding_tasks/utils.py`](diffhunk://#diff-5a48e07d336f9a7e22bc6a974d0c452b414dd57dea2ca836caa47395d04bf2a6R1-R15): A new utility function `strip_description_path` was added to sanitize URLs by removing '/description' or '/submissions' suffixes if present.

Application of New Utility Function:

* [`src/coding_tasks/views/users.py`](diffhunk://#diff-420429bcf7c277d895f2687ed242c3dc3e884711c3037097660092b11eaae3c5R15): The new `strip_description_path` utility function is now used to sanitize the URL when a new suggestion is added. [[1]](diffhunk://#diff-420429bcf7c277d895f2687ed242c3dc3e884711c3037097660092b11eaae3c5R15) [[2]](diffhunk://#diff-420429bcf7c277d895f2687ed242c3dc3e884711c3037097660092b11eaae3c5R39)